### PR TITLE
Await FSI job readiness before sending commands

### DIFF
--- a/after/ftplugin/fsharp.lua
+++ b/after/ftplugin/fsharp.lua
@@ -108,15 +108,12 @@ if not vim.g._fsharp_fsi_loaded then
     local text = table.concat(lines, nl)
     local payload = prefix .. text .. nl .. ";;" .. nl
 
-    local function really_send()
-      vim.api.nvim_chan_send(fsi.job, payload)
-    end
-
     if fresh then
-      vim.defer_fn(really_send, 120) -- wait for REPL banner:contentReference[oaicite:4]{index=4}
-    else
-      really_send()
+      vim.wait(1000, function()
+        return vim.fn.jobwait({ fsi.job }, 0)[1] == -1
+      end)
     end
+    vim.api.nvim_chan_send(fsi.job, payload)
   end
 
   function _FSharpEvalLineOrVisual()


### PR DESCRIPTION
## Summary
- replace fixed delay with `vim.wait` to wait until the F# Interactive job is running before sending input

## Testing
- `luacheck after/ftplugin/fsharp.lua`

------
https://chatgpt.com/codex/tasks/task_e_6894dc677e4c83258305072a2f6b919e