### PR TITLE
Stop F# FSI job on terminal cleanup

### DIFF
--- a/after/ftplugin/fsharp.lua
+++ b/after/ftplugin/fsharp.lua
@@ -88,6 +88,9 @@ if not vim.g._fsharp_fsi_loaded then
         buffer = fsi.buf,
         once = true,
         callback = function()
+          if fsi.job and vim.fn.jobwait({ fsi.job }, 0)[1] == -1 then
+            vim.fn.jobstop(fsi.job)
+          end
           fsi = { buf = nil, win = nil, job = nil }
         end,
       })


### PR DESCRIPTION
## Summary
- ensure F# Interactive terminal job is stopped before clearing stored state

## Testing
- `stylua --check after/ftplugin/fsharp.lua` *(fails: formatting differences)*
- `luacheck after/ftplugin/fsharp.lua`


------
https://chatgpt.com/codex/tasks/task_e_6894e2382eb08325b1f1e3d8330d5dff